### PR TITLE
Added issue priority sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ docker run -it -p 5000:5000 \
 
 Other environment variables:
 
-| Variable                      | Notes                                                             |
-|-------------------------------|-------------------------------------------------------------------|
-| REDMINE_ISSUE_STATUS_INWORK   | Redmine issue status id, when issue in work                       |
-| REDMINE_ISSUE_STATUS_DONE     | Redmine issue status id, when issue is done                       |
-| GITLAB_ISSUE_STATUS_DONE      | GitLab label title, when issue is done. Default is `Done`         |
-| REDMINE_ISSUE_STATUS_DECLINED | Redmine issue status id, when issue is declined                   |
-| GITLAB_ISSUE_STATUS_DECLINED  | GitLab label title, when issue is declined. Default is `Declined` |
+| Variable                       | Notes                                                             |
+|--------------------------------|-------------------------------------------------------------------|
+| REDMINE_ISSUE_STATUS_INWORK    | Redmine issue status id, when issue in work                       |
+| REDMINE_ISSUE_STATUS_DONE      | Redmine issue status id, when issue is done                       |
+| GITLAB_ISSUE_STATUS_DONE       | GitLab label title, when issue is done. Default is `Done`         |
+| REDMINE_ISSUE_STATUS_DECLINED  | Redmine issue status id, when issue is declined                   |
+| GITLAB_ISSUE_STATUS_DECLINED   | GitLab label title, when issue is declined. Default is `Declined` |
+| REDMINE_ISSUE_PRIORITY_DEFAULT | Redmine issue default priority                                    |
+| REDMINE_ISSUE_PRIORITY_BACKLOG | Redmine issue priority for backlog milestone                      |
+| GITLAB_MILESTONE_BACKLOG       | Milestone title for backlog priority. Default is `backlog`        |


### PR DESCRIPTION
Support default and backlog priority

Set environments:
1. REDMINE_ISSUE_PRIORITY_DEFAULT - default issue priority, if milestone title does not match. Default Redmine Normal priority has id `2`.
2. REDMINE_ISSUE_PRIORITY_BACKLOG - priority for backlog issues. Default Redmine Low priority has id `1`.
3. GITLAB_MILESTONE_BACKLOG - milestone title for backlog, default is `backlog`.
